### PR TITLE
feat: Agregar filtros por Marca, Modelo y Tipo en ProductListScreen

### DIFF
--- a/lib/features/products/data/models/product_model.dart
+++ b/lib/features/products/data/models/product_model.dart
@@ -9,6 +9,9 @@ class ProductModel {
   final String? features;
   final String? imageUrl;
   final String createdAt;
+  final String? brand;
+  final String? model;
+  final String? fuelType;
 
   ProductModel({
     required this.id,
@@ -19,6 +22,9 @@ class ProductModel {
     this.features,
     this.imageUrl,
     required this.createdAt,
+    this.brand,
+    this.model,
+    this.fuelType,
   });
 
   factory ProductModel.fromMap(Map<String, dynamic> data, String id) {
@@ -31,6 +37,9 @@ class ProductModel {
       features: data['features'],
       imageUrl: data['image_url'],
       createdAt: data['created_at'] ?? '',
+      brand: data['brand'],
+      model: data['model'],
+      fuelType: data['fuelType'],
     );
   }
 
@@ -43,6 +52,9 @@ class ProductModel {
       'features': features,
       'image_url': imageUrl,
       'created_at': createdAt,
+      'brand': brand,
+      'model': model,
+      'fuelType': fuelType,
     };
   }
 
@@ -56,6 +68,9 @@ class ProductModel {
       features: features,
       imageUrl: imageUrl,
       createdAt: createdAt,
+      brand: brand,
+      model: model,
+      fuelType: fuelType,
     );
   }
 }

--- a/lib/features/products/domain/entities/product.dart
+++ b/lib/features/products/domain/entities/product.dart
@@ -7,6 +7,9 @@ class Product {
   final String? features;
   final String? imageUrl;
   final String createdAt;
+  final String? brand;
+  final String? model;
+  final String? fuelType;
 
   Product({
     required this.id,
@@ -17,5 +20,8 @@ class Product {
     this.features,
     this.imageUrl,
     required this.createdAt,
+    this.brand,
+    this.model,
+    this.fuelType,
   });
 }

--- a/lib/features/products/presentation/providers/product_provider.dart
+++ b/lib/features/products/presentation/providers/product_provider.dart
@@ -4,17 +4,33 @@ import '../../domain/usecases/get_products.dart';
 
 class ProductProvider with ChangeNotifier {
   List<Product> _products = [];
+  List<Product> _filteredProducts = [];
   bool _isLoading = false;
   String? _errorMessage;
+  String? _selectedBrand;
+  String? _selectedModel;
+  String? _selectedType;
 
-  List<Product> get products => _products;
+  List<Product> get products => _filteredProducts;
   bool get isLoading => _isLoading;
   String? get errorMessage => _errorMessage;
+  String? get selectedBrand => _selectedBrand;
+  String? get selectedModel => _selectedModel;
+  String? get selectedType => _selectedType;
+
+  List<String> get brands =>
+      _products.map((product) => product.brand ?? 'Sin marca').toSet().toList()
+        ..sort();
+  List<String> get models =>
+      _products.map((product) => product.model ?? 'Sin modelo').toSet().toList()
+        ..sort();
+  List<String> get types =>
+      _products.map((product) => product.type).toSet().toList()..sort();
 
   final GetProducts getProductsUseCase;
 
   ProductProvider(this.getProductsUseCase) {
-    loadProducts(); // Cargar productos al inicializar
+    loadProducts();
   }
 
   Future<void> loadProducts() async {
@@ -29,6 +45,7 @@ class ProductProvider with ChangeNotifier {
       if (_products.isEmpty) {
         print('No se encontraron productos en Firestore.');
       }
+      _filteredProducts = _products;
     } catch (e) {
       print('Error al cargar productos: $e');
       _errorMessage = 'Error al cargar productos: $e';
@@ -36,5 +53,43 @@ class ProductProvider with ChangeNotifier {
       _isLoading = false;
       notifyListeners();
     }
+  }
+
+  void setBrand(String? brand) {
+    _selectedBrand = brand == 'Sin marca' ? null : brand;
+    _filterProducts();
+    notifyListeners();
+  }
+
+  void setModel(String? model) {
+    _selectedModel = model == 'Sin modelo' ? null : model;
+    _filterProducts();
+    notifyListeners();
+  }
+
+  void setType(String? type) {
+    _selectedType = type;
+    _filterProducts();
+    notifyListeners();
+  }
+
+  void _filterProducts() {
+    _filteredProducts = _products.where((product) {
+      final matchesBrand =
+          _selectedBrand == null || product.brand == _selectedBrand;
+      final matchesModel =
+          _selectedModel == null || product.model == _selectedModel;
+      final matchesType =
+          _selectedType == null || product.type == _selectedType;
+      return matchesBrand && matchesModel && matchesType;
+    }).toList();
+  }
+
+  void resetFilters() {
+    _selectedBrand = null;
+    _selectedModel = null;
+    _selectedType = null;
+    _filteredProducts = _products;
+    notifyListeners();
   }
 }

--- a/lib/features/products/presentation/screens/product_list_screen.dart
+++ b/lib/features/products/presentation/screens/product_list_screen.dart
@@ -30,37 +30,127 @@ class ProductListScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: productProvider.isLoading
-          ? const Center(child: CircularProgressIndicator())
-          : productProvider.errorMessage != null
-              ? Center(child: Text(productProvider.errorMessage!))
-              : productProvider.products.isEmpty
-                  ? const Center(child: Text('No hay máquinas disponibles'))
-                  : ListView.builder(
-                      itemCount: productProvider.products.length,
-                      itemBuilder: (context, index) {
-                        final product = productProvider.products[index];
-                        return Card(
-                          child: ListTile(
-                            title: Text(product.name),
-                            subtitle: Text(
-                                '${product.type} - ${product.price} ${product.currency}'),
-                            trailing: product.imageUrl != null
-                                ? Image.network(product.imageUrl!, width: 50)
-                                : const Icon(Icons.image_not_supported),
-                            onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) =>
-                                      BudgetFormScreen(product: product),
+      body: Column(
+        children: [
+          // Filtros
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: DropdownButtonFormField<String>(
+                        decoration: const InputDecoration(
+                          labelText: 'Marca',
+                          border: OutlineInputBorder(),
+                        ),
+                        value: productProvider.selectedBrand,
+                        items: productProvider.brands
+                            .map((brand) => DropdownMenuItem(
+                                  value: brand,
+                                  child: Text(brand),
+                                ))
+                            .toList(),
+                        onChanged: (value) => productProvider.setBrand(value),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: DropdownButtonFormField<String>(
+                        decoration: const InputDecoration(
+                          labelText: 'Modelo',
+                          border: OutlineInputBorder(),
+                        ),
+                        value: productProvider.selectedModel,
+                        items: productProvider.models
+                            .map((model) => DropdownMenuItem(
+                                  value: model,
+                                  child: Text(model),
+                                ))
+                            .toList(),
+                        onChanged: (value) => productProvider.setModel(value),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Expanded(
+                      child: DropdownButtonFormField<String>(
+                        decoration: const InputDecoration(
+                          labelText: 'Tipo',
+                          border: OutlineInputBorder(),
+                        ),
+                        value: productProvider.selectedType,
+                        items: productProvider.types
+                            .map((type) => DropdownMenuItem(
+                                  value: type,
+                                  child: Text(type),
+                                ))
+                            .toList(),
+                        onChanged: (value) => productProvider.setType(value),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      onPressed: () => productProvider.resetFilters(),
+                      child: const Text('Limpiar Filtros'),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          // Lista de productos
+          Expanded(
+            child: productProvider.isLoading
+                ? const Center(child: CircularProgressIndicator())
+                : productProvider.errorMessage != null
+                    ? Center(child: Text(productProvider.errorMessage!))
+                    : productProvider.products.isEmpty
+                        ? const Center(
+                            child: Text('No hay máquinas disponibles'))
+                        : ListView.builder(
+                            itemCount: productProvider.products.length,
+                            itemBuilder: (context, index) {
+                              final product = productProvider.products[index];
+                              return Card(
+                                child: ListTile(
+                                  title: Text(product.name),
+                                  subtitle: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                          '${product.type} - ${product.price} ${product.currency}'),
+                                      if (product.brand != null)
+                                        Text('Marca: ${product.brand}'),
+                                      if (product.model != null)
+                                        Text('Modelo: ${product.model}'),
+                                    ],
+                                  ),
+                                  trailing: product.imageUrl != null
+                                      ? Image.network(product.imageUrl!,
+                                          width: 50)
+                                      : const Icon(Icons.image_not_supported),
+                                  onTap: () {
+                                    Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (context) =>
+                                            BudgetFormScreen(product: product),
+                                      ),
+                                    );
+                                  },
                                 ),
                               );
                             },
                           ),
-                        );
-                      },
-                    ),
+          ),
+        ],
+      ),
       bottomNavigationBar: const Padding(
         padding: EdgeInsets.all(8.0),
         child: Text(


### PR DESCRIPTION
- Se añadieron desplegables con valores únicos desde Firestore.
- Actualizada estructura de Product para incluir brand, model y fuelType.
- Filtrado simultáneo y actualización automática de la lista.
- Botón para limpiar filtros.